### PR TITLE
Fix package links + add info about 2.x upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Hopefully this package will become quickly obsolete when the [CSS Modules Propos
 
 In the mean time, enjoy importing your CSS into your component files.
 
-- [Shared Logic](./lit-css)
-- [esbuild](./esbuild-plugin-lit-css)
-- [Webpack](./lit-css-loader)
-- [Rollup](./rollup-plugin-lit-css)
+- [Shared Logic](./packages/lit-css)
+- [esbuild](./packages/esbuild-plugin-lit-css)
+- [Webpack](./packages/lit-css-loader)
+- [Rollup](./packages/rollup-plugin-lit-css)

--- a/packages/rollup-plugin-lit-css/README.md
+++ b/packages/rollup-plugin-lit-css/README.md
@@ -95,3 +95,19 @@ class CSSinCSS extends FASTElement {}
 
 Looking for webpack? [lit-css-loader](../lit-css-loader)
 Looking for esbuild? [esbuild-plugin-lit-css](../esbuild-plugin-lit-css)
+
+## Upgrade from version `2.x`
+
+Starting with version `3.x`, the default import used when transforming the CSS files is `lit` (see `specifier` option above) which is LitElement 3.x. If you need this package to work with [LitElement 2.x](https://lit-element.polymer-project.org/), you have to set the specifier to `lit-element` like so:
+
+```js
+import config from './rollup.config.rest.js'
+import litcss from 'rollup-plugin-lit-css';
+
+export default {
+  ...config,
+  plugins: [
+    litcss({ specifier: 'lit-element' })
+  ]
+}
+```


### PR DESCRIPTION
This PR fixes the package links in the main README.md

Also, I have added a small chapter about upgrading `rollup-plugin-lit-css` from the previous version + using LitElement 2.x