### PR TITLE
fix(web-dev-server): properly bust cache

### DIFF
--- a/.changeset/plenty-planes-know.md
+++ b/.changeset/plenty-planes-know.md
@@ -1,0 +1,5 @@
+---
+"web-dev-server-plugin-lit-css": patch
+---
+
+Properly invalidate browser cache for transformed CSS files

--- a/packages/web-dev-server-plugin-lit-css/web-dev-server-plugin-lit-css.ts
+++ b/packages/web-dev-server-plugin-lit-css/web-dev-server-plugin-lit-css.ts
@@ -25,20 +25,23 @@ export function litCss(options?: LitCSSOptions): Plugin {
     name: 'lit-css',
 
     async transform(ctx) {
-      const { path, body } = ctx;
-      if (filter(path)) {
-        // bust the cache
-        ctx.set('Cache-Control', 'no-cache');
-        ctx.set('ETag', Date.now().toString());
-        ctx.set('Last-Modified', new Date().toString());
-        return transform({
-          css: body as string,
+      if (filter(ctx.path)) {
+        const headers = {
+          'Cache-Control': 'no-store, no-cache, must-revalidate',
+          'ETag': Date.now().toString(),
+          'Last-Modified': new Date().toString(),
+          'pragma': 'no-cache',
+          'expires': '0',
+        };
+        const body = await transform({
+          css: ctx.body as string,
           specifier,
           tag,
           uglify,
-          filePath: path,
+          filePath: ctx.path,
           ...rest,
         });
+        return { body, headers, transformCache: false };
       }
     },
 
@@ -50,5 +53,3 @@ export function litCss(options?: LitCSSOptions): Plugin {
 }
 
 export default litCss;
-
-


### PR DESCRIPTION
Upon investigating https://github.com/patternfly/patternfly-elements/issues/2376#event-8540923755 I found that returning a `TransformResult` as object, and including within both cache headers and setting `transformCache` to false improved the situation 