### PR TITLE
chore: Bump lit-css 3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13790,7 +13790,7 @@
       "version": "3.0.1",
       "license": "ISC",
       "dependencies": {
-        "@pwrs/lit-css": "^3.0.0"
+        "@pwrs/lit-css": "^3.0.1"
       },
       "peerDependencies": {
         "esbuild": ">=0.16.17 <0.24.0",
@@ -13809,7 +13809,7 @@
     },
     "packages/lit-css": {
       "name": "@pwrs/lit-css",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "ISC",
       "dependencies": {
         "cssnano": "^7.0.6"
@@ -13819,7 +13819,7 @@
       "version": "3.0.0",
       "license": "ISC",
       "dependencies": {
-        "@pwrs/lit-css": "^3.0.0",
+        "@pwrs/lit-css": "^3.0.1",
         "loader-utils": "^3.2.1"
       }
     },
@@ -13827,7 +13827,7 @@
       "version": "5.0.1",
       "license": "ISC",
       "dependencies": {
-        "@pwrs/lit-css": "^3.0.0",
+        "@pwrs/lit-css": "^3.0.1",
         "@rollup/pluginutils": "^5.1.0"
       }
     },
@@ -13835,7 +13835,7 @@
       "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
-        "@pwrs/lit-css": "^3.0.0"
+        "@pwrs/lit-css": "^3.0.1"
       },
       "peerDependencies": {
         "clean-css": "^5",
@@ -13850,7 +13850,7 @@
       "version": "3.0.1",
       "license": "ISC",
       "dependencies": {
-        "@pwrs/lit-css": "^3.0.0",
+        "@pwrs/lit-css": "^3.0.1",
         "@rollup/pluginutils": "^5.1.0"
       }
     },

--- a/packages/esbuild-plugin-lit-css/package.json
+++ b/packages/esbuild-plugin-lit-css/package.json
@@ -32,7 +32,7 @@
     "esbuild-plugin-lit-css.d.ts"
   ],
   "dependencies": {
-    "@pwrs/lit-css": "^3.0.0"
+    "@pwrs/lit-css": "^3.0.1"
   },
   "peerDependencies": {
     "esbuild": ">=0.16.17 <0.24.0",

--- a/packages/lit-css-loader/package.json
+++ b/packages/lit-css-loader/package.json
@@ -32,7 +32,7 @@
     "lit-css-loader.d.ts"
   ],
   "dependencies": {
-    "@pwrs/lit-css": "^3.0.0",
+    "@pwrs/lit-css": "^3.0.1",
     "loader-utils": "^3.2.1"
   }
 }

--- a/packages/rollup-plugin-lit-css/package.json
+++ b/packages/rollup-plugin-lit-css/package.json
@@ -31,7 +31,7 @@
     "rollup-plugin-lit-css.d.ts"
   ],
   "dependencies": {
-    "@pwrs/lit-css": "^3.0.0",
+    "@pwrs/lit-css": "^3.0.1",
     "@rollup/pluginutils": "^5.1.0"
   }
 }

--- a/packages/typescript-transform-lit-css/package.json
+++ b/packages/typescript-transform-lit-css/package.json
@@ -37,7 +37,7 @@
     "typescript-transform-lit-css.d.ts"
   ],
   "dependencies": {
-    "@pwrs/lit-css": "^3.0.0"
+    "@pwrs/lit-css": "^3.0.1"
   },
   "peerDependencies": {
     "clean-css": "^5",

--- a/packages/web-dev-server-plugin-lit-css/package.json
+++ b/packages/web-dev-server-plugin-lit-css/package.json
@@ -31,7 +31,7 @@
     "web-dev-server-plugin-lit-css.d.ts"
   ],
   "dependencies": {
-    "@pwrs/lit-css": "^3.0.0",
+    "@pwrs/lit-css": "^3.0.1",
     "@rollup/pluginutils": "^5.1.0"
   }
 }


### PR DESCRIPTION
Bumps `lit-css` to 3.0.1 in all the packages, based on https://github.com/bennypowers/lit-css/pull/62